### PR TITLE
ci: bump actions/upload-artifact SHA to current v4

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -79,7 +79,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json


### PR DESCRIPTION
Fixes estate-wide Hypatia Security Scan + Static Analysis Gate red. The pinned SHA `65c79d7...` for `actions/upload-artifact@v4` no longer resolves; current v4 = `ea165f8d`. Tracked in `hyperpolymath/hypatia#213`.