### PR TITLE
chore: drop `*` wildcard from CODEOWNERS to stop Dependabot review pings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,6 @@
 # CODEOWNERS - Evidence Graph for Investigative Journalism (bofig)
 
 # Default owner for all files
-* @hyperpolymath
 
 # Core domain logic
 /lib/evidence_graph/ @hyperpolymath


### PR DESCRIPTION
The catch-all `* @hyperpolymath` line in CODEOWNERS causes GitHub to auto-request review on every Dependabot PR (since every PR touches at least one owned path under `*`). With the sole maintainer being the same user, those review requests are pure notification noise.

This drops the wildcard line while preserving any path-specific ownership and SPDX/license headers. Path-specific lines are intentional and stay.

Human PRs from collaborators still trigger path-owner review where applicable; Dependabot PRs typically only touch root manifest files which are no longer matched.