### PR TITLE
chore(codeowners): drop .github/workflows/ line - standards#55 follow-up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 
 # Security-sensitive files
 /config/ @hyperpolymath
-/.github/workflows/ @hyperpolymath
 /SECURITY.md @hyperpolymath
 
 # Machine-readable state


### PR DESCRIPTION
Follow-up to the wildcard drop (already merged). Drops the path-specific .github/workflows/ @hyperpolymath line so Dependabot github-actions ecosystem PRs no longer auto-request review via CODEOWNERS.

Policy decided in hyperpolymath/standards#55: solo-owned repos get no functional gating from the line.

idaptik (co-owner @JoshuaJewell), reasonably-good-token-vault, and protocol-squisher are NOT in this batch: token-vault and protocol-squisher already do not have the line, and idaptik needs JoshuaJewell's input.