### PR TITLE
chore(ci): convert elixir-ci.yml to wrapper of standards reusable

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -1,54 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
-permissions:
-  contents: read
+# Thin wrapper around hyperpolymath/standards elixir-ci-reusable.yml.
+# See standards#174 for the reusable's purpose.
 
 name: Elixir CI
 on: [push, pull_request]
-npermissions:
-  contents: read
 
+permissions:
+  contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-npermissions:
-  contents: read
-
-    env:
-      MIX_ENV: test
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1
-        with:
-          otp-version: '26'
-npermissions:
-  contents: read
-
-          elixir-version: '1.15'
-npermissions:
-  contents: read
-
-      
-      - name: Cache deps
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
-        with:
-          path: deps
-          key: deps-${{ hashFiles('mix.lock') }}
-      
-      - name: Install deps
-        run: mix deps.get
-      
-      - name: Compile
-        run: mix compile --warnings-as-errors
-      
-      - name: Credo lint
-        run: mix credo --strict
-      
-      - name: Dialyzer
-        run: mix dialyzer
-      
-      - name: Run tests
-        run: mix test --cover
-      
-      - name: Security check
-        run: mix deps.audit || true
+  elixir-ci:
+    uses: hyperpolymath/standards/.github/workflows/elixir-ci-reusable.yml@4fdf4314b4ab54269adbaff10e30e483b5e86845
+    with:
+      otp-version: "26"
+      elixir-version: "1.15"


### PR DESCRIPTION
## Summary

Replaces the per-repo `elixir-ci.yml` copy (50+ lines of duplicated plumbing) with a 16-line wrapper calling `hyperpolymath/standards/.github/workflows/elixir-ci-reusable.yml@4fdf4314b4ab54269adbaff10e30e483b5e86845` (standards#174 HEAD SHA).

Same pattern as the rust-ci wrapper sweep filed 2026-05-26.

## Pin-to-not-yet-merged-SHA

Intentional: the SHA points at standards#174's PR HEAD, not main. This wrapper file is staged but the action runner won't load the reusable until standards#174 lands on main. Per estate-template-propagation guidance.

## Test plan

- [ ] `pull_request` triggers run the wrapper unchanged from main (target-branch semantics)
- [ ] After standards#174 merges, the next push exercises the reusable end-to-end
- [ ] OTP 26 / Elixir 1.15 preserved (the prior `elixir-ci.yml` pinned these)

Refs standards#174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)