### PR TITLE
docs(claude-md): flip ReScript→AffineScript per 2026-05-25 estate language policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -114,19 +114,19 @@ LithClient.exists_by_hash?("evidence", sha256_hash)
 | Language/Tool | Use Case | Notes |
 |---------------|----------|-------|
 | **Elixir** | This project's primary language | Phoenix, LiveView, Absinthe |
-| **ReScript** | Primary application code | Compiles to JS, type-safe |
+| **AffineScript** | Primary application code | Affine-typed, compiles to typed-wasm or Deno-ESM |
 | **Deno** | Runtime & package management | Replaces Node/npm/bun |
 | **Rust** | Performance-critical, systems, WASM | Preferred for CLI tools |
 | **Gleam** | Backend services | Runs on BEAM or compiles to JS |
 | **Bash/POSIX Shell** | Scripts, automation | Keep minimal |
-| **JavaScript** | Only where ReScript cannot | D3.js hooks in this project |
+| **JavaScript** | Only where AffineScript cannot | D3.js hooks in this project |
 | **Guile Scheme** | State/meta files | .machine_readable/6a2/STATE.a2ml, .machine_readable/6a2/META.a2ml, .machine_readable/6a2/ECOSYSTEM.a2ml |
 
 ### BANNED - Do Not Use
 
 | Banned | Replacement |
 |--------|-------------|
-| TypeScript | ReScript |
+| TypeScript | AffineScript |
 | Node.js | Deno |
 | npm/Bun/pnpm/yarn | Deno |
 | Go | Rust |


### PR DESCRIPTION
Per the 2026-05-25 estate language policy
([standards#252](https://github.com/hyperpolymath/standards/issues/252)),
the `.claude/CLAUDE.md` language-policy table in this repo named ReScript
as the primary application language and as the TypeScript replacement.
Flip both to AffineScript via the same 6-line template substitution used
in the dev-eco/phronesis/dotfiles initial sweep.

## Substitutions applied

1. `**ReScript** | Primary application code | Compiles to JS, type-safe`
   → `**AffineScript** | Primary application code | Affine-typed, compiles to typed-wasm or Deno-ESM`
2. `Only where ReScript cannot` → `Only where AffineScript cannot`
3. `| TypeScript | ReScript |` (BANNED replacement) → `| TypeScript | AffineScript |`
4. `Web UI (ReScript)` → `Web UI (AffineScript)`
5. `Convert existing TS to ReScript` → `Convert existing TS to AffineScript`
6. `ReScript for apps` → `AffineScript for apps`

## Scope check (template-clone class)

This repo was categorised in the 2026-05-30 100-repo survey as a
**template-clone** or **template-clone-with-stubs** — meaning the
CLAUDE.md is a generic policy template clone rather than describing
ReScript-heavy local reality. Repos with substantive ReScript source
(≥5 `.res` files) were deferred to per-repo review per the
`panll`-precedent (panll#60 closed because the local reality didn't
match a wholesale flip).

Docs-only — no source changes. No CI runs are expected to fail on
behaviour grounds; if any do, that is unrelated tech debt to surface
separately.

Refs hyperpolymath/standards#287 (CLAUDE.md docs slice umbrella)
Refs hyperpolymath/standards#252 (parent ReScript→AffineScript tracker)