### PR TITLE
ci: cut Actions burn — scope push triggers + concurrency-cancel

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -3,7 +3,16 @@
 # See standards#174 for the reusable's purpose.
 
 name: Elixir CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+# Estate guardrail: scope push to default branches so a PR fires once (not
+# push+PR), and cancel superseded runs. Safe — read-only PR-triggered check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/rescript-deno-ci.yml
+++ b/.github/workflows/rescript-deno-ci.yml
@@ -3,7 +3,16 @@ permissions:
   contents: read
 
 name: Deno CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+# Estate guardrail: scope push to default branches so a PR fires once (not
+# push+PR), and cancel superseded runs. Safe — read-only PR-triggered check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Scope `push` to default branches (kills push+PR double-runs) and add `concurrency: cancel-in-progress` to read-only PR-triggered checks. Part of the estate CI-burn reduction (Actions spending-limit wall). Files changed: 2. No SPDX/logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)