### PR TITLE
fix(ci): pin rebar3-version (bypass builds.hex.pm cert error)

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -23,3 +23,4 @@ jobs:
     with:
       otp-version: "27.2.1"
       elixir-version: "1.18.2"
+      rebar3-version: '3.24.0'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -53,6 +53,7 @@ jobs:
       uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
       with:
         elixir-version: '1.18.2'
+        rebar3-version: '3.24.0'
         otp-version: '27.2.1'
     - name: Restore dependencies cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
The 'Build and test' failures are an OTP TLS key_usage_mismatch fetching rebar from builds.hex.pm (not transient — re-run still fails). Pinning rebar3-version makes setup-beam install rebar3 from GitHub releases instead, bypassing the bad cert. Clears all 6 open dependabot PRs once rebased.